### PR TITLE
Switch Prisma datasource to Postgres for Neon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
 # Copy to .env.local and fill in as needed
-DATABASE_URL="file:./dev.db"
+# Postgres connection string (e.g., Neon)
+DATABASE_URL="postgresql://USER:PASSWORD@HOST/DB_NAME?sslmode=require"
 OPENAI_API_KEY="sk-..."
-# If deploying with Postgres (e.g., Supabase/Azure), use:
-# DATABASE_URL="postgresql://user:password@host:5432/gymtrack"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Track gym sessions (exercises, sets, reps, RPE) and get tailored feedback and we
 
 ## Stack
 - Next.js 14 (App Router) + TypeScript
-- Prisma ORM + SQLite (switchable to Postgres)
+- Prisma ORM + PostgreSQL (Neon)
 - Minimal CSS (you can add Tailwind/shadcn/ui)
 - REST route handlers for sessions, profile, and AI coach
 - OpenAI Chat Completions for coaching
@@ -24,7 +24,7 @@ Open http://localhost:3000
 Set `OPENAI_API_KEY` in `.env.local`. The AI route uses `gpt-4.1-mini` by default—swap models as desired.
 
 ## DB
-Default is SQLite (local). To use Postgres (Supabase/Azure Flexible Server), set `DATABASE_URL` accordingly and update `datasource` in `prisma/schema.prisma`.
+This project uses PostgreSQL by default. Provide your Neon connection string in `DATABASE_URL` and Prisma will connect using the PostgreSQL provider defined in `prisma/schema.prisma`.
 
 ## Auth
 This starter uses a single default user row. Swap in NextAuth/Azure AD when ready and link `UserProfile` by auth user id/email.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 


### PR DESCRIPTION
## Summary
- use PostgreSQL datasource in Prisma schema
- document Neon connection string and Postgres default in env example and README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt requires ESLint config)*
- `npm run build` *(fails: Can't reach database server at `ep-odd-shape-a7bgj41y-pooler.ap-southeast-2.aws.neon.tech:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_6895cc5c786883219f7d3fa7a80b3d64