### PR TITLE
Configure Prisma for Neon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Copy to .env.local and fill in as needed
 DATABASE_URL="file:./dev.db"
 OPENAI_API_KEY="sk-..."
-# If deploying with Postgres (e.g., Supabase/Azure), use:
+# If deploying with Postgres (e.g., Supabase/Azure/Neon), use:
 # DATABASE_URL="postgresql://user:password@host:5432/gymtrack"
+# For Neon, set a direct connection URL for migrations:
+# DIRECT_URL="postgresql://user:password@host:5432/gymtrack?sslmode=require"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Open http://localhost:3000
 Set `OPENAI_API_KEY` in `.env.local`. The AI route uses `gpt-4.1-mini` by default—swap models as desired.
 
 ## DB
-Default is SQLite (local). To use Postgres (Supabase/Azure Flexible Server), set `DATABASE_URL` accordingly and update `datasource` in `prisma/schema.prisma`.
+Default is SQLite (local). To use Postgres (Supabase/Azure Flexible Server/Neon), set `DATABASE_URL` accordingly and update `datasource` in `prisma/schema.prisma`.
+If using Neon with connection pooling, also set `DIRECT_URL` for migrations.
 
 ## Auth
 This starter uses a single default user row. Swap in NextAuth/Azure AD when ready and link `UserProfile` by auth user id/email.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,9 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model UserProfile {


### PR DESCRIPTION
## Summary
- switch Prisma datasource to postgresql and add direct URL for Neon
- document `DIRECT_URL` usage for Neon deployments

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6895ceb3ccec8321ac8388d27c946a04