### PR TITLE
Mark Prisma-backed routes as dynamic

### DIFF
--- a/app/api/ai/coach/route.ts
+++ b/app/api/ai/coach/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 
+export const dynamic = 'force-dynamic';
+
 export const maxDuration = 60;
 
 async function buildContext() {

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,6 +1,8 @@
 import { prisma } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET() {
   let user = await prisma.userProfile.findFirst();
   if (!user) user = await prisma.userProfile.create({ data: {} });

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,6 +1,8 @@
 import { prisma } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET() {
   const sessions = await prisma.session.findMany({
     orderBy: { performedAt: 'desc' },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,8 @@
 import { prisma } from '@/lib/prisma';
 import SessionForm from '@/components/SessionForm';
 
+export const dynamic = 'force-dynamic';
+
 export default async function HomePage() {
   const sessions = await prisma.session.findMany({
     orderBy: { performedAt: 'desc' },


### PR DESCRIPTION
## Summary
- prevent build-time database access by marking Prisma page and API routes as dynamic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895d0ffe4b88321b5522ca550aa4f8a