### PR TITLE
Add accessible dark/light theme toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,33 @@
 * { box-sizing: border-box; }
-html, body { margin: 0; padding: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji; background: #fafafa; color: #111; }
-a { color: inherit; }
-input, textarea, button { font: inherit; }
-.border { border: 1px solid #ddd; }
+:root {
+  --bg: #fafafa;
+  --text: #111;
+  --border: #ddd;
+}
+[data-theme='dark'] {
+  --bg: #111;
+  --text: #fafafa;
+  --border: #444;
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji;
+  background: var(--bg);
+  color: var(--text);
+}
+a {
+  color: inherit;
+}
+input,
+textarea,
+button {
+  font: inherit;
+}
+.border {
+  border: 1px solid var(--border);
+}
 .rounded { border-radius: 8px; }
 .p-2 { padding: .5rem; } .p-3 { padding: .75rem; } .p-6 { padding: 1.5rem; }
 .mx-auto { margin-left: auto; margin-right: auto; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,18 @@
 import './globals.css';
 import type { Metadata } from 'next';
+import ThemeToggle from '../components/ThemeToggle';
 
 export const metadata: Metadata = {
   title: 'GymTrack AI',
   description: 'Track sessions and get AI coaching',
-  themeColor: '#000000',
   manifest: '/manifest.json',
+};
+
+export const viewport = {
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#fafafa' },
+    { media: '(prefers-color-scheme: dark)', color: '#111' },
+  ],
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -15,7 +22,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <div className="max-w-5xl mx-auto p-6">
           <header className="mb-6 flex items-center justify-between">
             <h1 className="text-3xl font-bold">GymTrack AI</h1>
-            <a className="underline" href="/coach">AI Coach</a>
+            <div className="flex items-center gap-2">
+              <a className="underline" href="/coach">AI Coach</a>
+              <ThemeToggle />
+            </div>
           </header>
           {children}
         </div>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") as "light" | "dark" | null;
+    const preferred =
+      stored || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+    setTheme(preferred);
+    document.documentElement.dataset.theme = preferred;
+  }, []);
+
+  const toggle = () => {
+    const next = theme === "light" ? "dark" : "light";
+    setTheme(next);
+    document.documentElement.dataset.theme = next;
+    localStorage.setItem("theme", next);
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
+      className="border rounded p-2"
+    >
+      {theme === "light" ? "🌙" : "☀️"}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce CSS variables and dark theme palette for WCAG-compliant contrast
- add a theme toggle button with local storage and aria labels
- expose theme colors via Next.js viewport metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*
- `npm run build` *(fails: PrismaClientInitializationError: the URL must start with the protocol `file:`)*

------
https://chatgpt.com/codex/tasks/task_e_6895cec600e88321b031f2ba97b2d2d1